### PR TITLE
Add Dockerfile

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -12,8 +12,8 @@ end_date: 2020-07-31
 release_tag: 2020-july
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
-docker_repo: DOCKER-REPOSITORY
-docker_tag: DOCKER-TAG
+docker_repo: training_rnaseq
+docker_tag: 2020-july
 # These are for loading Docker images from a file; only relevant for in-person
 docker_targz: ccdl_docker_image.tar.gz
 docker_tar: ccdl_docker_image.tar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM rocker/tidyverse:3.6.1
-MAINTAINER ccdl@alexslemonade.org
+LABEL maintainer="ccdl@alexslemonade.org"
 WORKDIR /rocker-build/
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
@@ -69,7 +69,7 @@ ENV PACKAGES git gcc make g++ libboost-all-dev liblzma-dev libbz2-dev \
     ca-certificates zlib1g-dev curl unzip autoconf
 
 ENV SALMON_VERSION 1.2.1
-WORKDIR /home
+WORKDIR /usr/local/src
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ${PACKAGES} && \
@@ -78,4 +78,6 @@ RUN apt-get update && \
 RUN wget https://github.com/COMBINE-lab/salmon/releases/download/v${SALMON_VERSION}/salmon-${SALMON_VERSION}_linux_x86_64.tar.gz
 RUN tar xzf salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
     rm -f salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
-    sudo ln -s /home/salmon-latest_linux_x86_64/bin/salmon /usr/local/bin/salmon
+    ln -s /usr/local/src/salmon-latest_linux_x86_64/bin/salmon /usr/local/bin/salmon
+ 
+WORKDIR /home/rstudio

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+FROM rocker/tidyverse:3.6.1
+MAINTAINER ccdl@alexslemonade.org
+WORKDIR /rocker-build/
+
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+RUN apt-get install dialog apt-utils -y
+
+RUN apt-get update -qq && apt-get -y --no-install-recommends install \
+    build-essential \
+    libxml2-dev \
+    libsqlite-dev \
+    libmariadbd-dev \
+    libmariadbclient-dev \
+    libmariadb-client-lgpl-dev \
+    libpq-dev \
+    libssh2-1-dev \
+    pandoc \
+    libmagick++-dev \
+    time
+
+RUN install2.r \
+    rjson \ 
+    ggpubr \
+    colorspace\
+    Rtsne \
+    umap
+
+ENV BIOCONDUCTOR_VERSION 3.10
+RUN R -e "BiocManager::install(c('ensembldb', 'DESeq2', 'qvalue',\
+    'org.Hs.eg.db', 'org.Dr.eg.db', 'org.Mm.eg.db', 'org.Cf.eg.db',\
+    'ComplexHeatmap', 'ConsensusClusterPlus', 'scran', 'scater',\
+    'tximport', 'alevinQC'), \
+    version = '${BIOCONDUCTOR_VERSION}', update = FALSE)"
+
+# FastQC
+RUN apt update && apt install -y fastqc
+
+# fastp 
+ENV FASTP_VERSION 0.20.1
+RUN git clone https://github.com/OpenGene/fastp.git
+RUN cd fastp && \
+    git checkout tags/v${FASTP_VERSION} -b v${FASTP_VERSION} && \
+    make && \
+    sudo make install
+
+# MultiQC
+ENV MULTIQC_VERSION 1.8
+RUN apt update && apt install -y python3-pip
+RUN pip3 install multiqc==${MULTIQC_VERSION}
+
+ENV PACKAGES git gcc make g++ libboost-all-dev liblzma-dev libbz2-dev \
+    ca-certificates zlib1g-dev curl unzip autoconf
+
+ENV SALMON_VERSION 1.2.1
+WORKDIR /home
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ${PACKAGES} && \
+    apt-get clean
+
+RUN wget https://github.com/COMBINE-lab/salmon/releases/download/v${SALMON_VERSION}/salmon-${SALMON_VERSION}_linux_x86_64.tar.gz
+RUN tar xzf salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
+    rm -f salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
+    sudo ln -s /home/salmon-latest_linux_x86_64/bin/salmon /usr/local/bin/salmon

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,13 +23,26 @@ RUN install2.r \
     ggpubr \
     colorspace\
     Rtsne \
-    umap
+    umap \
+    uwot \
+    plotly \
+    hexbin \
+    optparse \
+    fastqcr \
+    tweenr \
+    polyclip \
+    ggraph \
+    ggforce \
+    ggupset \
+    msigdbr \
+    FNN
 
 ENV BIOCONDUCTOR_VERSION 3.10
 RUN R -e "BiocManager::install(c('ensembldb', 'DESeq2', 'qvalue',\
     'org.Hs.eg.db', 'org.Dr.eg.db', 'org.Mm.eg.db', 'org.Cf.eg.db',\
     'ComplexHeatmap', 'ConsensusClusterPlus', 'scran', 'scater',\
-    'tximport', 'alevinQC'), \
+    'tximport', 'alevinQC', 'vsn', 'GEOquery', 'AnnotationHub',\
+    'fishpond', 'clusterProfiler', 'GSVA', 'qusage', 'graph'),\
     version = '${BIOCONDUCTOR_VERSION}', update = FALSE)"
 
 # FastQC
@@ -47,6 +60,10 @@ RUN cd fastp && \
 ENV MULTIQC_VERSION 1.8
 RUN apt update && apt install -y python3-pip
 RUN pip3 install multiqc==${MULTIQC_VERSION}
+
+# Snakemake
+ENV SNAKEMAKE_VERSION 5.19.3
+RUN pip3 install snakemake==${SNAKEMAKE_VERSION}
 
 ENV PACKAGES git gcc make g++ libboost-all-dev liblzma-dev libbz2-dev \
     ca-certificates zlib1g-dev curl unzip autoconf


### PR DESCRIPTION
Closes #7.

This is ready to be pushed as `ccdl/training_rnaseq:2020-july` (and `latest`) on my local machine once the Dockerfile gets approved. Because a version of the Dockerfile went into the `2020-may-training` repository, I'd recommend focusing Dockerfile review on https://github.com/AlexsLemonade/2020-july-training/commit/a141ece4c7521b0fba04995be65f39e418c8c743. 

I used the version of Snakemake that was returned by `snakemake --version` on the RStudio Server. I don't know that we need to pin the versions of its dependencies because I expect it will not impact _processing_ which we are most concerned about but looking for feedback on that, too.